### PR TITLE
updates for stereo/multi-channel functionality

### DIFF
--- a/p2fa/align.py
+++ b/p2fa/align.py
@@ -6,6 +6,7 @@
       	-r sampling_rate -- override which sample rate model to use, one of 8000, 11025, and 16000
         -s start_time    -- start of portion of wavfile to align (in seconds, default 0)
         -e end_time      -- end of portion of wavfile to align (in seconds, defaul to end)
+        -c channel       -- channel to align (default 1) # change by EWW; stereo functionality
 			
 	You can also import this file as a module and use the functions directly.
 """
@@ -33,6 +34,7 @@ def prep_wav(orig_wav, out_wav, sr_override, wave_start, wave_end):
     f.close()
     
     soxopts = ""
+    soxopts += " remix " + str(channel) # change by EWW; stereo functionality
     if float(wave_start) != 0.0 or wave_end != None :
     	soxopts += " trim " + wave_start
     	if wave_end != None :
@@ -266,7 +268,7 @@ def getopt2(name, opts, default = None) :
 if __name__ == '__main__':
 	
 	try:
-		opts, args = getopt.getopt(sys.argv[1:], "r:s:e:", ["model="])
+		opts, args = getopt.getopt(sys.argv[1:], "r:s:e:c:", ["model="])
 		
 		# get the three mandatory arguments
 		if len(args) != 3 :
@@ -279,6 +281,7 @@ if __name__ == '__main__':
 		wave_end = getopt2("-e", opts, None)
 		surround_token = "sp" #getopt2("-p", opts, 'sp')
 		between_token = "sp" #getopt2("-b", opts, 'sp')
+                channel = getopt2("-c", opts, "1") # change by EWW; stereo functionality
 		
 		if surround_token.strip() == "":
 			surround_token = None

--- a/python/multi_align
+++ b/python/multi_align
@@ -280,10 +280,11 @@ if __name__ == '__main__':
     outcodec=None
     incodec=None
     align_cmd = 'pyalign'
+    pat = re.compile(r'(.+):(\d+)$')
     for o, a in opts:
         if o in ("--tiers"):
-            tiersfull = [item + ':1'  if re.search(':[0-9]$',item) is None else item for item in a.split(',')] # default to channel 1
-            tiersdict = dict(item.split(':') for item in tiersfull) # convert to dict with tier names as keys and channel as values
+            tiersfull = [item + ':1'  if pat.search(item) is None else item for item in a.split(',')] # default to channel 1
+            tiersdict = dict([(m.group(1), m.group(2)) for item in tiersfull for m in [pat.search(item)]]) # convert to dict with tier names as keys and channel as values
             # TO-DO; this will break if colons are included elsewhere in the string
             tiernames = tiersdict.keys()
         elif o in ("--dict-codec"):

--- a/python/multi_align
+++ b/python/multi_align
@@ -73,6 +73,8 @@ Optional parameters:
 
     If the --tiers parameter is not used, then all tiers will be aligned.
 
+    To align specific tiers to stereo or multi-channel audio, specify channel assignments by putting a colon and then the channel number after the tier name.
+
         Examples:
 
         # Align labels in tier named 'speaker'
@@ -80,6 +82,9 @@ Optional parameters:
 
         # Align labels in tiers named 'speaker1' and 'speaker2'
         --tiers speaker1,speaker2
+
+        # Align labels in tier 'speaker' to channel 1 and in tier 'speaker2' to channel 2
+        --tiers speaker1,speaker2:2
 
     --dict-codec codec
     Codec from the Python codec module used for decoding of the aligner's
@@ -192,9 +197,9 @@ Note that the tier is passed by reference and altered in place.'''
     for l in labels:
         tier.add(l)
 
-def multi_align_tier(tier, wav, pattern=None, dictcodec=None,
+def multi_align_tier(tier, wav, channel, pattern=None, dictcodec=None,
         align_cmd='pyalign'):
-    '''Align all the non-emtpy labels in a tier on wav. Return the output
+    '''Align all the non-empty labels in a tier on wav. Return the output
 phone and word tiers.'''
     temp_tg = 'temp_textgrid.TextGrid'
     temp_txt = 'temp_transcript.txt'
@@ -221,6 +226,7 @@ phone and word tiers.'''
             align_cmd,
             '-s', str(lab.t1),
             '-e', str(lab.t2),
+            '-c', str(channel),
             wav,
             temp_txt,
             temp_tg
@@ -276,7 +282,10 @@ if __name__ == '__main__':
     align_cmd = 'pyalign'
     for o, a in opts:
         if o in ("--tiers"):
-            tiernames = a.split(',')
+            tiersfull = [item + ':1'  if re.search(':[0-9]$',item) is None else item for item in a.split(',')] # default to channel 1
+            tiersdict = dict(item.split(':') for item in tiersfull) # convert to dict with tier names as keys and channel as values
+            # TO-DO; this will break if colons are included elsewhere in the string
+            tiernames = tiersdict.keys()
         elif o in ("--dict-codec"):
             dictcodec = a
         elif o in ("--out-codec"):
@@ -335,9 +344,14 @@ if __name__ == '__main__':
             sys.exit(3)
 
     for tier in tiers:
+        try:
+            channel = tiersdict[tier.name]
+        except NameError: # no tiersdict because no --tiers arg
+            channel = 1
         phonetier, wordtier = multi_align_tier(
             tier,
             wav,
+            channel,
             pattern=pattern,
             dictcodec=dictcodec,
             align_cmd=align_cmd


### PR DESCRIPTION
These changes incorporate functionality for aligning specific tiers to specific channels in stereo/multi-channel audio. 

As noted in the updated standard usage help, channel numbers are indicated in the tiers string, with a colon separating tier names and channel assignments. The default channel is 1. 

The current version lacks robust checking against possible colons in other places in the tier name, which could introduce unwanted behavior.  For now, the best practice is to not use colons except to indicate channel assignments. 
